### PR TITLE
Add profile settings and saved items tabs to dashboard

### DIFF
--- a/src/components/dashboard/CareerDashboardTabs.tsx
+++ b/src/components/dashboard/CareerDashboardTabs.tsx
@@ -2,14 +2,20 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CareerProgress } from "@/components/profile/CareerProgress";
 import { CareerPreferences } from "@/components/profile/CareerPreferences";
 import { SkillRecommendations } from "@/components/profile/SkillRecommendations";
+import { ProfileSettingsTab } from "@/components/profile/ProfileSettingsTab";
+import { SavedOpportunities } from "@/components/profile/SavedOpportunities";
+import { ResumeUpload } from "@/components/profile/ResumeUpload";
 
 export function CareerDashboardTabs() {
   return (
     <Tabs defaultValue="progress" className="w-full">
-      <TabsList className="grid w-full grid-cols-3">
+      <TabsList className="grid w-full grid-cols-2 gap-2 md:grid-cols-6">
         <TabsTrigger value="progress">Career Progress</TabsTrigger>
         <TabsTrigger value="preferences">Goals & Preferences</TabsTrigger>
         <TabsTrigger value="recommendations">Skill Recommendations</TabsTrigger>
+        <TabsTrigger value="settings">Profile Settings</TabsTrigger>
+        <TabsTrigger value="saved">Saved Items</TabsTrigger>
+        <TabsTrigger value="resume">Resume Upload</TabsTrigger>
       </TabsList>
       <TabsContent value="progress" className="mt-4">
         <CareerProgress />
@@ -19,6 +25,15 @@ export function CareerDashboardTabs() {
       </TabsContent>
       <TabsContent value="recommendations" className="mt-4">
         <SkillRecommendations />
+      </TabsContent>
+      <TabsContent value="settings" className="mt-4">
+        <ProfileSettingsTab />
+      </TabsContent>
+      <TabsContent value="saved" className="mt-4">
+        <SavedOpportunities />
+      </TabsContent>
+      <TabsContent value="resume" className="mt-4">
+        <ResumeUpload />
       </TabsContent>
     </Tabs>
   );

--- a/src/components/profile/AccountSettingsForm.tsx
+++ b/src/components/profile/AccountSettingsForm.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { useToast } from "@/hooks/use-toast";
+import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/context/AuthContext";
+
+interface UserSettings {
+  theme: string;
+  email_notifications: boolean;
+}
+
+const themeOptions = [
+  { value: "default", label: "Default" },
+  { value: "ocean", label: "Ocean" },
+  { value: "sunset", label: "Sunset" },
+  { value: "forest", label: "Forest" },
+  { value: "midnight", label: "Midnight" },
+];
+
+export function AccountSettingsForm() {
+  const { toast } = useToast();
+  const { user } = useAuth();
+  const [isSaving, setIsSaving] = useState(false);
+  const [settings, setSettings] = useState<UserSettings>({
+    theme: "default",
+    email_notifications: true,
+  });
+
+  useEffect(() => {
+    const loadSettings = async () => {
+      if (!user) return;
+
+      const { data, error } = await supabase
+        .from("user_settings")
+        .select("theme, email_notifications")
+        .eq("user_id", user.id)
+        .maybeSingle();
+
+      if (error) {
+        toast({
+          title: "Unable to load settings",
+          description: "We couldn't fetch your preferences. Try again later.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      if (data) {
+        setSettings({
+          theme: data.theme ?? "default",
+          email_notifications: data.email_notifications ?? true,
+        });
+      }
+    };
+
+    loadSettings();
+  }, [user, toast]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!user) {
+      toast({
+        title: "You must be signed in",
+        description: "Log in to update your account settings.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setIsSaving(true);
+
+    const { error } = await supabase.from("user_settings").upsert({
+      user_id: user.id,
+      theme: settings.theme,
+      email_notifications: settings.email_notifications,
+      updated_at: new Date().toISOString(),
+    });
+
+    setIsSaving(false);
+
+    if (error) {
+      toast({
+        title: "Unable to save settings",
+        description: "Please try again.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    toast({
+      title: "Settings updated",
+      description: "Your preferences were saved successfully.",
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Account Settings</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="space-y-2">
+            <Label htmlFor="theme">Dashboard Theme</Label>
+            <Select
+              value={settings.theme}
+              onValueChange={(value) =>
+                setSettings((prev) => ({ ...prev, theme: value }))
+              }
+            >
+              <SelectTrigger id="theme">
+                <SelectValue placeholder="Select a theme" />
+              </SelectTrigger>
+              <SelectContent>
+                {themeOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex items-center justify-between rounded-lg border p-4">
+            <div className="space-y-1">
+              <Label htmlFor="email-notifications" className="text-base">
+                Email Notifications
+              </Label>
+              <p className="text-sm text-muted-foreground">
+                Receive updates about job matches and career insights.
+              </p>
+            </div>
+            <Switch
+              id="email-notifications"
+              checked={settings.email_notifications}
+              onCheckedChange={(checked) =>
+                setSettings((prev) => ({ ...prev, email_notifications: checked }))
+              }
+            />
+          </div>
+
+          <Button type="submit" className="w-full" disabled={isSaving}>
+            {isSaving ? "Saving..." : "Save Settings"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/profile/ProfileSettingsTab.tsx
+++ b/src/components/profile/ProfileSettingsTab.tsx
@@ -1,0 +1,11 @@
+import { ProfileEdit } from "./ProfileEdit";
+import { AccountSettingsForm } from "./AccountSettingsForm";
+
+export function ProfileSettingsTab() {
+  return (
+    <div className="grid gap-6 lg:grid-cols-2">
+      <ProfileEdit />
+      <AccountSettingsForm />
+    </div>
+  );
+}

--- a/src/components/profile/ResumeUpload.tsx
+++ b/src/components/profile/ResumeUpload.tsx
@@ -57,7 +57,7 @@ export function ResumeUpload() {
       // Update user profile with resume URL
       await supabase
         .from('profiles')
-        .update({ resume_url: publicUrl } as any)
+        .update({ resume_url: publicUrl } as Record<string, unknown>)
         .eq('user_id', user.id);
 
       toast({
@@ -68,12 +68,20 @@ export function ResumeUpload() {
       // Trigger resume parsing and analysis
       const parsedResume = await parseResume(publicUrl);
       const jobMatches = await findJobMatches(parsedResume);
-      
+
+      const enrichedMatches = jobMatches.slice(0, 10).map((match) => ({
+        ...match,
+        saved: false,
+      }));
+
       // Store parsed resume data and job matches
-      await supabase.from('profiles').update({
-        parsed_resume: parsedResume,
-        job_matches: jobMatches.slice(0, 10) // Store top 10 matches
-      } as any).eq('user_id', user.id);
+      await supabase
+        .from('profiles')
+        .update({
+          parsed_resume: parsedResume,
+          job_matches: enrichedMatches, // Store top 10 matches with saved flag
+        } as Record<string, unknown>)
+        .eq('user_id', user.id);
 
       toast({
         title: "Resume Analyzed",

--- a/src/components/profile/SavedOpportunities.tsx
+++ b/src/components/profile/SavedOpportunities.tsx
@@ -1,0 +1,388 @@
+import { useEffect, useMemo, useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { supabase } from "@/integrations/supabase/client";
+import { useToast } from "@/hooks/use-toast";
+import { Loader2, Bookmark } from "lucide-react";
+
+type JobMatch = {
+  title: string;
+  company: string;
+  score: number;
+  matchingSkills: string[];
+  saved?: boolean;
+  link?: string;
+};
+
+type SavedCourse = {
+  id: string;
+  title: string;
+  provider: string;
+  focusArea: string;
+  link: string;
+  saved: boolean;
+};
+
+const defaultCourses: SavedCourse[] = [
+  {
+    id: "aws-ai",
+    title: "AWS Machine Learning Specialty",
+    provider: "Amazon Web Services",
+    focusArea: "Cloud & AI",
+    link: "https://www.aws.training",
+    saved: false,
+  },
+  {
+    id: "meta-front-end",
+    title: "Meta Front-End Developer Professional Certificate",
+    provider: "Coursera",
+    focusArea: "Front-end Engineering",
+    link: "https://www.coursera.org",
+    saved: false,
+  },
+  {
+    id: "mit-ai",
+    title: "Machine Learning with Python",
+    provider: "MIT xPro",
+    focusArea: "Data Science",
+    link: "https://xpro.mit.edu",
+    saved: false,
+  },
+];
+
+export function SavedOpportunities() {
+  const { toast } = useToast();
+  const [loadingMatches, setLoadingMatches] = useState(true);
+  const [jobMatches, setJobMatches] = useState<JobMatch[]>([]);
+  const [courses, setCourses] = useState<SavedCourse[]>(defaultCourses);
+  const [showAllMatches, setShowAllMatches] = useState(false);
+
+  useEffect(() => {
+    const storedCourses =
+      typeof window !== "undefined"
+        ? window.localStorage.getItem("aspiration-saved-courses")
+        : null;
+
+    if (storedCourses) {
+      try {
+        const parsed = JSON.parse(storedCourses) as SavedCourse[];
+        setCourses(parsed);
+      } catch (error) {
+        console.warn("Unable to parse saved courses from storage", error);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(
+        "aspiration-saved-courses",
+        JSON.stringify(courses)
+      );
+    }
+  }, [courses]);
+
+  useEffect(() => {
+    const loadMatches = async () => {
+      setLoadingMatches(true);
+      const { data: authData } = await supabase.auth.getUser();
+
+      if (!authData.user) {
+        setLoadingMatches(false);
+        return;
+      }
+
+      const { data, error } = await supabase
+        .from("profiles")
+        .select("job_matches")
+        .eq("user_id", authData.user.id)
+        .single();
+
+      if (error) {
+        toast({
+          title: "Unable to load job matches",
+          description: "Please try again later.",
+          variant: "destructive",
+        });
+        setLoadingMatches(false);
+        return;
+      }
+
+      const matches = (data?.job_matches as JobMatch[] | null) ?? [];
+      setJobMatches(
+        matches.map((match) => ({
+          ...match,
+          saved: match.saved ?? false,
+        }))
+      );
+      setLoadingMatches(false);
+    };
+
+    loadMatches();
+  }, [toast]);
+
+  const savedJobs = useMemo(
+    () => jobMatches.filter((match) => match.saved),
+    [jobMatches]
+  );
+
+  const savedCourses = useMemo(
+    () => courses.filter((course) => course.saved),
+    [courses]
+  );
+
+  const matchesToDisplay = showAllMatches ? jobMatches : savedJobs;
+
+  const toggleJobSaved = async (index: number) => {
+    const updatedMatches = jobMatches.map((match, idx) =>
+      idx === index ? { ...match, saved: !match.saved } : match
+    );
+
+    setJobMatches(updatedMatches);
+
+    const { data: authData } = await supabase.auth.getUser();
+    if (!authData.user) {
+      toast({
+        title: "Sign in required",
+        description: "Log in to keep items in your saved list.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const { error } = await supabase
+      .from("profiles")
+      .update({ job_matches: updatedMatches as unknown as JobMatch[] })
+      .eq("user_id", authData.user.id);
+
+    if (error) {
+      toast({
+        title: "Couldn't update saved jobs",
+        description: "Please try again.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const isSavedNow = updatedMatches[index].saved;
+    toast({
+      title: isSavedNow ? "Job saved" : "Job removed",
+      description: isSavedNow
+        ? "We'll keep this role handy for you."
+        : "This role has been removed from your saved list.",
+    });
+  };
+
+  const toggleCourseSaved = (courseId: string) => {
+    setCourses((prev) =>
+      prev.map((course) =>
+        course.id === courseId
+          ? {
+              ...course,
+              saved: !course.saved,
+            }
+          : course
+      )
+    );
+
+    const course = courses.find((item) => item.id === courseId);
+    const isSaved = course?.saved;
+
+    toast({
+      title: isSaved ? "Course removed" : "Course saved",
+      description: isSaved
+        ? "The course has been removed from your saved list."
+        : "Course added to your saved learning plan.",
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader className="space-y-1">
+          <CardTitle>Saved Roles</CardTitle>
+          <CardDescription>
+            Keep track of the jobs that match your resume and feel worth
+            revisiting.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-sm text-muted-foreground">
+              {showAllMatches
+                ? "Showing every role we've analyzed from your resume."
+                : "Showing only the positions you've saved."}
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowAllMatches((prev) => !prev)}
+            >
+              {showAllMatches ? "View saved" : "View all matches"}
+            </Button>
+          </div>
+
+          {loadingMatches ? (
+            <div className="flex items-center justify-center py-8 text-muted-foreground">
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Loading matches…
+            </div>
+          ) : matchesToDisplay.length === 0 ? (
+            <div className="rounded-lg border border-dashed p-6 text-center">
+              <Bookmark className="mx-auto mb-3 h-8 w-8 text-muted-foreground" />
+              <p className="font-medium text-foreground">No saved roles yet</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Upload your resume or browse recommendations to save roles that
+                inspire you.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {matchesToDisplay.map((match, index) => (
+                <div
+                  key={`${match.title}-${match.company}-${index}`}
+                  className="rounded-lg border p-4"
+                >
+                  <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                    <div>
+                      <h3 className="text-lg font-semibold text-foreground">
+                        {match.title}
+                      </h3>
+                      <p className="text-sm text-muted-foreground">
+                        {match.company}
+                      </p>
+                    </div>
+                    <Button
+                      variant={match.saved ? "secondary" : "outline"}
+                      onClick={() => toggleJobSaved(jobMatches.indexOf(match))}
+                    >
+                      {match.saved ? "Saved" : "Save role"}
+                    </Button>
+                  </div>
+                  <Separator className="my-4" />
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant="outline">Match score: {(match.score * 100).toFixed(0)}%</Badge>
+                    {match.matchingSkills.slice(0, 5).map((skill) => (
+                      <Badge key={skill} variant="secondary">
+                        {skill}
+                      </Badge>
+                    ))}
+                  </div>
+                  {match.link && (
+                    <Button
+                      variant="link"
+                      className="mt-2 px-0"
+                      onClick={() => window.open(match.link, "_blank")}
+                    >
+                      View posting
+                    </Button>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="space-y-1">
+          <CardTitle>Saved Courses & Certifications</CardTitle>
+          <CardDescription>
+            Build a learning path that supports your next career move.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {savedCourses.length === 0 ? (
+            <div className="rounded-lg border border-dashed p-6 text-center">
+              <p className="font-medium text-foreground">No saved courses yet</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Tap the save button on any course to keep it on your radar.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {savedCourses.map((course) => (
+                <div
+                  key={course.id}
+                  className="rounded-lg border p-4"
+                >
+                  <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                    <div>
+                      <h3 className="text-lg font-semibold text-foreground">
+                        {course.title}
+                      </h3>
+                      <p className="text-sm text-muted-foreground">
+                        {course.provider} • {course.focusArea}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => window.open(course.link, "_blank")}
+                      >
+                        Explore
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => toggleCourseSaved(course.id)}
+                      >
+                        Remove
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <Separator />
+
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              Not seeing the right course? Save one of these recommendations to
+              build your personalized learning list.
+            </p>
+            <div className="grid gap-3 md:grid-cols-3">
+              {courses.map((course) => (
+                <div
+                  key={`suggested-${course.id}`}
+                  className="rounded-lg border p-4"
+                >
+                  <div className="space-y-2">
+                    <div>
+                      <h3 className="text-base font-semibold text-foreground">
+                        {course.title}
+                      </h3>
+                      <p className="text-xs text-muted-foreground">
+                        {course.provider} • {course.focusArea}
+                      </p>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <Button
+                        variant="link"
+                        className="px-0"
+                        onClick={() => window.open(course.link, "_blank")}
+                      >
+                        View
+                      </Button>
+                      <Button
+                        variant={course.saved ? "secondary" : "outline"}
+                        size="sm"
+                        onClick={() => toggleCourseSaved(course.id)}
+                      >
+                        {course.saved ? "Saved" : "Save"}
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extend the dashboard tab set with dedicated tabs for profile settings, saved opportunities, and resume uploads
- add account settings management, saved role/course views, and reuse the existing resume upload flow within the dashboard experience
- enrich stored job matches with metadata to support saving items from the UI

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e143ef36c08333bd1751216ba6b5c4